### PR TITLE
[FEAT-11] Add Topic class and methods 

### DIFF
--- a/src/models/Topic.ts
+++ b/src/models/Topic.ts
@@ -1,0 +1,38 @@
+import { prisma } from "@/db";
+import { handleErrors } from "./utils";
+
+type NewTopicType = {
+  title: string;
+  description: string;
+  userId: number;
+}
+
+type TopicType = NewTopicType & {
+  id: number;
+};
+
+class Topic {
+  id: number;
+  title: string;
+  description: string;
+  userId: number;
+
+  constructor({ id, title, description, userId }: TopicType) {
+    this.id = id;
+    this.title = title;
+    this.description = description;
+    this.userId = userId;
+  }
+
+  static async create(data: NewTopicType): Promise<Topic | null> {
+    const newTopic = await prisma.topic.create({ data }).catch(handleErrors);
+    return newTopic ? new Topic(newTopic) : null;
+  }
+
+  static async findMany(): Promise<Topic[]> {
+    const topics = await prisma.topic.findMany().catch(handleErrors);
+    return (topics || []).map((topic) => new Topic(topic));
+  }
+}
+
+export default Topic;

--- a/src/models/Topic.ts
+++ b/src/models/Topic.ts
@@ -1,16 +1,6 @@
 import { prisma } from "@/db";
 import { handleErrors } from "./utils";
 
-type NewTopicType = {
-  title: string;
-  description: string;
-  userId: number;
-}
-
-type TopicType = NewTopicType & {
-  id: number;
-};
-
 class Topic {
   id: number;
   title: string;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -81,10 +81,10 @@ class User {
     return prisma.topic.findMany({ where: { userId: this.id } });
   }
 
-  async createNewTopic(title: string, description: string) {
+  async createNewTopic({ title, description }: RawTopicType): Promise<TopicType | null> {
     return prisma.topic.create({
       data: { title, description, userId: this.id },
-    });
+    }).catch(handleErrors);
   }
 }
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -76,6 +76,16 @@ class User {
 
     return user ? new User(user) : null;
   }
+
+  async getTopics() {
+    return prisma.topic.findMany({ where: { userId: this.id } });
+  }
+
+  async createNewTopic(title: string, description: string) {
+    return prisma.topic.create({
+      data: { title, description, userId: this.id },
+    });
+  }
 }
 
 export default User;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,3 +2,24 @@
 type PropsWithChildren = {
   children: React.ReactNode;
 }
+
+// TOPICS //////////////////////////////////////
+// I know I could extend, but then I lose the properties on the VSCode peak
+// I care more about that then dry types. LOOKING FOR A FIX
+type RawTopicType = {
+  title: string;
+  description: string;
+}
+
+type NewTopicType = {
+  title: string;
+  description: string;
+  userId: number;
+}
+
+type TopicType = {
+  id: number;
+  title: string;
+  description: string;
+  userId: number;
+}


### PR DESCRIPTION
Closes #11 

Wound up being smaller, the db and migrations were already created. Not sure I'll ever need a full Topic class as I'll likely always go through the user, but there it is. 

Note: I know that I can extend types, but I lose the peak window, so I'm keeping the types explicit for now. 