### PR TITLE
[FEAT-14] Add topics sidebar 

### DIFF
--- a/src/app/notes/[topicId]/page.tsx
+++ b/src/app/notes/[topicId]/page.tsx
@@ -1,0 +1,7 @@
+export default function TopicSubPage() {
+  return (
+    <>
+      <h2>Topic Sub Page</h2>
+    </>
+  );
+}

--- a/src/app/notes/[topicId]/page.tsx
+++ b/src/app/notes/[topicId]/page.tsx
@@ -1,7 +1,20 @@
-export default function TopicSubPage() {
+import Topic from "@/models/Topic";
+
+type SubPageProps = { params: { topicId: string; } };
+
+export default async function TopicSubPage({ params: { topicId } }: SubPageProps) {
+  // Coming soon, add notes and resources to this query
+  const topic = await Topic.findWithNotesAndResources(Number(topicId));
+  if (!topic) return <p>Topic not found</p>;
+
+  const { title, description } = topic;
+
   return (
-    <>
-      <h2>Topic Sub Page</h2>
-    </>
+    <section aria-labelledby="topic-title">
+      <h1 id="topic-title" className="text-4xl font-bold mt-8 mb-4">
+        {title} Notes
+      </h1>
+      {!!description && <p>{description}</p>}
+    </section>
   );
 }

--- a/src/app/notes/layout.tsx
+++ b/src/app/notes/layout.tsx
@@ -17,13 +17,10 @@ export default async function RootLayout({
   const topics = await user.getTopics();
   return (
     <>
-      <h1 className='text-4xl font-bold mt-8 mb-4'>Notes</h1>
-      <section className="flex gap-4">
-
+      <div className="flex gap-4">
         <TopicsSidebar topics={topics} />
         {children}
-
-      </section>
+      </div >
     </>
   );
 }

--- a/src/app/notes/layout.tsx
+++ b/src/app/notes/layout.tsx
@@ -3,8 +3,11 @@ import { redirect } from 'next/navigation';
 import User from '@/models/User';
 import TopicsSidebar from '@/components/TopicsSideBar';
 
-// this is a protected route
-export default async function NotesPage({ children }) {
+export default async function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
   const session = await getServerSession();
   if (!session?.user?.email) return redirect('/');
 
@@ -12,10 +15,15 @@ export default async function NotesPage({ children }) {
   if (!user) return redirect('/');
 
   const topics = await user.getTopics();
-
   return (
     <>
-      <p>Select some notes to get started</p>
+      <h1 className='text-4xl font-bold mt-8 mb-4'>Notes</h1>
+      <section className="flex gap-4">
+
+        <TopicsSidebar topics={topics} />
+        {children}
+
+      </section>
     </>
   );
 }

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -1,6 +1,7 @@
 import { getServerSession } from 'next-auth';
 import { redirect } from 'next/navigation';
 import User from '@/models/User';
+import TopicsSidebar from '@/components/TopicsSideBar';
 
 // this is a protected route
 export default async function NotesPage() {
@@ -10,9 +11,12 @@ export default async function NotesPage() {
   const user = await User.findByEmail(session.user.email);
   if (!user) return redirect('/');
 
+  const topics = await user.getTopics();
+
   return (
     <>
       <h1 className='text-4xl font-bold mt-8 mb-4'>Notes</h1>
+      <TopicsSidebar topics={topics} />
     </>
   );
 }

--- a/src/app/notes/page.tsx
+++ b/src/app/notes/page.tsx
@@ -1,21 +1,9 @@
-import { getServerSession } from 'next-auth';
-import { redirect } from 'next/navigation';
-import User from '@/models/User';
-import TopicsSidebar from '@/components/TopicsSideBar';
-
-// this is a protected route
-export default async function NotesPage({ children }) {
-  const session = await getServerSession();
-  if (!session?.user?.email) return redirect('/');
-
-  const user = await User.findByEmail(session.user.email);
-  if (!user) return redirect('/');
-
-  const topics = await user.getTopics();
-
+export default async function NotesPage() {
+  // TODO: Get a default starting note somehow
   return (
-    <>
+    <section aria-label="Notes">
+      <h1 className="text-4xl font-bold mt-8 mb-4" >Notes</h1>
       <p>Select some notes to get started</p>
-    </>
+    </section>
   );
 }

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -26,7 +26,7 @@ export default function NavBar() {
       <a href="/" className="flex items-center space-x-3 rtl:space-x-reverse">
         <span className="self-center text-2xl font-semibold whitespace-nowrap dark:text-white">Ollie Notes</span>
       </a>
-      <nav className="bg-white border-gray-200 dark:bg-gray-900">
+      <nav aria-label="Main" className="bg-white border-gray-200 dark:bg-gray-900">
         <ul className="flex space-x-2">
           <li className={createClassNameWithActiveLink('/articles')} >
             <Link href="/articles">Articles</Link>

--- a/src/components/TopicsSideBar.tsx
+++ b/src/components/TopicsSideBar.tsx
@@ -1,0 +1,14 @@
+export default function TopicsSidebar({ topics }: { topics: TopicType[] }) {
+  return (
+    <aside>
+      <h2>Topics</h2>
+      <ul>
+        {
+          topics.map((topic) => (
+            <li key={topic.id}>{topic.title}</li>
+          ))
+        }
+      </ul>
+    </aside>
+  );
+}

--- a/src/components/TopicsSideBar.tsx
+++ b/src/components/TopicsSideBar.tsx
@@ -1,10 +1,11 @@
 import Link from "next/link";
 
 export default function TopicsSidebar({ topics }: { topics: TopicType[] }) {
+  // https://rocketvalidator.com/accessibility-validation/axe/4.8/landmark-complementary-is-top-level
+  // This is why this is a pure nav, and not an aside.
   return (
-    <aside>
+    <div>
       <nav aria-label="Topics">
-        <h2>Topics</h2>
         <ul>
           {
             topics.map((topic) => (
@@ -17,6 +18,10 @@ export default function TopicsSidebar({ topics }: { topics: TopicType[] }) {
           }
         </ul>
       </nav>
-    </aside>
+      <form>
+        {/* TODO: This will pop open a modal later */}
+        <button className="text-white bg-green-700 hover:bg-blue-700 font-medium rounded-lg text-sm px-2 py-2" aria-label="Create New Topic" title="Create New Topic" type="submit">+</button>
+      </form>
+    </div>
   );
 }

--- a/src/components/TopicsSideBar.tsx
+++ b/src/components/TopicsSideBar.tsx
@@ -1,14 +1,22 @@
+import Link from "next/link";
+
 export default function TopicsSidebar({ topics }: { topics: TopicType[] }) {
   return (
     <aside>
-      <h2>Topics</h2>
-      <ul>
-        {
-          topics.map((topic) => (
-            <li key={topic.id}>{topic.title}</li>
-          ))
-        }
-      </ul>
+      <nav aria-label="Topics">
+        <h2>Topics</h2>
+        <ul>
+          {
+            topics.map((topic) => (
+              <li key={topic.id}>
+                <Link href={`/notes/${topic.id}`} className="text-blue-600 hover:underline underline">
+                  {topic.title}
+                </Link>
+              </li>
+            ))
+          }
+        </ul>
+      </nav>
     </aside>
   );
 }

--- a/src/models/Topic.ts
+++ b/src/models/Topic.ts
@@ -1,0 +1,28 @@
+import { prisma } from "@/db";
+import { handleErrors } from "./utils";
+
+class Topic {
+  id: number;
+  title: string;
+  description: string;
+  userId: number;
+
+  constructor({ id, title, description, userId }: TopicType) {
+    this.id = id;
+    this.title = title;
+    this.description = description;
+    this.userId = userId;
+  }
+
+  static async create(data: NewTopicType): Promise<Topic | null> {
+    const newTopic = await prisma.topic.create({ data }).catch(handleErrors);
+    return newTopic ? new Topic(newTopic) : null;
+  }
+
+  static async findMany(): Promise<Topic[]> {
+    const topics = await prisma.topic.findMany().catch(handleErrors);
+    return (topics || []).map((topic) => new Topic(topic));
+  }
+}
+
+export default Topic;

--- a/src/models/Topic.ts
+++ b/src/models/Topic.ts
@@ -19,6 +19,18 @@ class Topic {
     return newTopic ? new Topic(newTopic) : null;
   }
 
+  static async findWithNotesAndResources(id: number): Promise<Topic | null> {
+    const topic = await prisma.topic
+      .findUnique(
+        {
+          where: { id },
+          // include: { notes: true, resources: true }
+        }
+      )
+      .catch(handleErrors);
+    return topic ? new Topic(topic) : null;
+  }
+
   static async findMany(): Promise<Topic[]> {
     const topics = await prisma.topic.findMany().catch(handleErrors);
     return (topics || []).map((topic) => new Topic(topic));

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -76,6 +76,16 @@ class User {
 
     return user ? new User(user) : null;
   }
+
+  async getTopics() {
+    return prisma.topic.findMany({ where: { userId: this.id } });
+  }
+
+  async createNewTopic({ title, description }: RawTopicType): Promise<TopicType | null> {
+    return prisma.topic.create({
+      data: { title, description, userId: this.id },
+    }).catch(handleErrors);
+  }
 }
 
 export default User;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -2,3 +2,24 @@
 type PropsWithChildren = {
   children: React.ReactNode;
 }
+
+// TOPICS //////////////////////////////////////
+// I know I could extend, but then I lose the properties on the VSCode peak
+// I care more about that then dry types. LOOKING FOR A FIX
+type RawTopicType = {
+  title: string;
+  description: string;
+}
+
+type NewTopicType = {
+  title: string;
+  description: string;
+  userId: number;
+}
+
+type TopicType = {
+  id: number;
+  title: string;
+  description: string;
+  userId: number;
+}


### PR DESCRIPTION
Closes #14 

Pretty sure this is the best way to handle routing, but we may update that in the future. For now the topic method is just stubbing out the notes and resources (I looked up, I believe that the include prop is how prisma does it). We don't have a public API so it's ok that we aren't protecting the topics in any way. Pretty sure that's obvious, but this is a new server render paradigm, just double checking I'm ok. 

